### PR TITLE
Feature: use current buffer as prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,28 @@ Set the following variables in your vimrc file.
 
 | Variable | Type | Required | Description |
 |:---------|:----:|:--------:|:------------|
-| g:chatgpt_apikey | string | Required | Your API key. |
-| g:chatgpt_maxtoken | number | optional | The number of max token. The default value is 1000. |
+| g:chatgpt_apikey | string | required | Your API key. |
+| g:chatgpt_maxtoken | number | optional | The number of max token. The default value is `1000`. |
+| g:chatgpt_focus_result | boolean | optional | 0: go back to the last edit buffer, 1: move the cursor to the new buffer with result. The default value is `0`. |
 
 
 ## How to use
+
+### Input prompt in Command Mode
 
 ```
 :Chatgpt "List the 3 popular NBA players"
 ```
 
 It will open a new buffer and show the completion response.
+
+### Input prompt from current buffer
+
+```
+:Chatgpt
+```
+
+That will take current buffer's all content as prompt to ChatGPT.
 
 
 ## License

--- a/doc/openai.txt
+++ b/doc/openai.txt
@@ -14,11 +14,16 @@ COMMANDS                                        *openai-commands*
 CONFIGURATION                                   *openai-configuration*
 
 * set ChatGPT API Key
-  let g:chatgpt_apikey='...'
+  let g:chatgpt_apikey = '...'
 
 * set ChatGPT max token
   " This is optional, the default value is 1000.
-  let g:chatgpt_maxtoken=1000
+  let g:chatgpt_maxtoken = 1000
+
+* set focusing on result, the cursor will be on the new buffer with result.
+  " This is optional, the default value is 0 (false).
+  let g:chatgpt_focus_result = 1
+
 
 ABOUT                                           *openai-about*
 

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -18,6 +18,10 @@ function s:func_chatgpt(prompt) abort
     else
       let s:maxtoken = get(g:, 'chatgpt_maxtoken')
     endif
+
+    if !exists(a:prompt)
+      let a:prompt = join(getline(1, '$'), '\n')
+    endif
     
     if !exists("s:request_cmd")
       let s:request_cmd = 'curl https://api.openai.com/v1/completions -H ''Content-Type: application/json'' -H ''Authorization: Bearer ' . s:apikey . ''' -d ''{"model": "text-davinci-002", "prompt": "PROMPT", "max_tokens": ' . s:maxtoken . '}'''

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -1,12 +1,13 @@
 scriptencoding utf-8
 
-com -nargs=0 ChatgptCurrent call s:func_chatgpt()
-com -nargs=1 Chatgpt call s:func_chatgpt(<args>)
+" command! -nargs=0 ChatgptCurrent call s:func_chatgpt()
+command! -nargs=* Chatgpt call s:func_chatgpt(<args>)
 
 function! s:func_chatgpt(prompt = '') abort
 
     " g:chatgpt_apikey: API Key.
     " g:chatgpt_maxtoken: the maximum length of a sequence of tokens that a text generation model can produce.
+    " g:chatgrp_focus_result: the current buffer will be on the result buffer if set to be 1, otherwise, on the last edit buffer.
     if !exists('g:chatgpt_apikey')
       echo 'API Key is not set. Please set g:chatgpt_apikey in your vimrc file.'
       return
@@ -20,9 +21,16 @@ function! s:func_chatgpt(prompt = '') abort
       let s:maxtoken = get(g:, 'chatgpt_maxtoken')
     endif
 
-    echo a:prompt
+    if !exists('g:chatgpt_focus_result')
+      let s:focus_result = 0
+    else 
+      let s:focus_result = 1
+    endif
+    echo s:focus_result
+
     if a:prompt == ''
       let s:prompt = join(getline(1, '$'), '\n')
+      " Replace the newline with empty string, because the newline will be escapted as ^@ and cause the request fails.
       let s:prompt = substitute(s:prompt,'\\n','','g')
     else
       let s:prompt = get(a:, 'prompt', '')
@@ -31,7 +39,6 @@ function! s:func_chatgpt(prompt = '') abort
       let s:request_cmd = 'curl https://api.openai.com/v1/completions -H ''Content-Type: application/json'' -H ''Authorization: Bearer ' . s:apikey . ''' -d ''{"model": "text-davinci-002", "prompt": "PROMPT", "max_tokens": ' . s:maxtoken . '}'''
     endif
     let s:request = substitute(s:request_cmd,"PROMPT",s:prompt,"")
-    echom s:request
     " let s:request = substitute(s:request,"\\\\","","g")
     " let s:response = system("./chatgpt.sh")
     if has("gui_running")
@@ -47,8 +54,10 @@ function! s:func_chatgpt(prompt = '') abort
     call setline(1, split(s:choice['text'], "\n"))
     " execute '$read !'. s:request
 
-    " go back to original window
-    wincmd p
+    if !get(s:, 'focus_result')
+      " go back to original window
+      wincmd p
+    endif
 endfunction
 
 

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -1,8 +1,9 @@
 scriptencoding utf-8
 
+com -nargs=0 ChatgptCurrent call s:func_chatgpt()
 com -nargs=1 Chatgpt call s:func_chatgpt(<args>)
 
-function s:func_chatgpt(prompt) abort
+function! s:func_chatgpt(prompt = '') abort
 
     " g:chatgpt_apikey: API Key.
     " g:chatgpt_maxtoken: the maximum length of a sequence of tokens that a text generation model can produce.
@@ -19,14 +20,18 @@ function s:func_chatgpt(prompt) abort
       let s:maxtoken = get(g:, 'chatgpt_maxtoken')
     endif
 
-    if !exists(a:prompt)
-      let a:prompt = join(getline(1, '$'), '\n')
+    echo a:prompt
+    if a:prompt == ''
+      let s:prompt = join(getline(1, '$'), '\n')
+      let s:prompt = substitute(s:prompt,'\\n','','g')
+    else
+      let s:prompt = get(a:, 'prompt', '')
     endif
-    
     if !exists("s:request_cmd")
       let s:request_cmd = 'curl https://api.openai.com/v1/completions -H ''Content-Type: application/json'' -H ''Authorization: Bearer ' . s:apikey . ''' -d ''{"model": "text-davinci-002", "prompt": "PROMPT", "max_tokens": ' . s:maxtoken . '}'''
     endif
-    let s:request = substitute(s:request_cmd,"PROMPT",a:prompt,"")
+    let s:request = substitute(s:request_cmd,"PROMPT",s:prompt,"")
+    echom s:request
     " let s:request = substitute(s:request,"\\\\","","g")
     " let s:response = system("./chatgpt.sh")
     if has("gui_running")


### PR DESCRIPTION
- Supports using current buffer as prompt.
- New option `g:chatgpt_focus_result`.